### PR TITLE
Added some missing constants

### DIFF
--- a/unrar/constants.py
+++ b/unrar/constants.py
@@ -103,5 +103,5 @@ UCM_NEEDPASSWORDW = 4
 #
 # Change volume callback message
 #
-RAR_VOL_ASK           0
-RAR_VOL_NOTIFY        1
+RAR_VOL_ASK = 0
+RAR_VOL_NOTIFY = 1


### PR DESCRIPTION
These constants are used when receiving a UCM_CHANGEVOLUME callback message.
