### PR TITLE
Exceptions

### DIFF
--- a/unrar/constants.py
+++ b/unrar/constants.py
@@ -69,6 +69,11 @@ ERAR_SMALL_BUF = 20
 ERAR_UNKNOWN = 21
 # Missing password error
 ERAR_MISSING_PASSWORD = 22
+# Reference error
+ERAR_EREFERENCE = 23
+# Bad password error
+ERAR_BAD_PASSWORD = 24
+
 
 #
 # Comments state

--- a/unrar/rarfile.py
+++ b/unrar/rarfile.py
@@ -220,6 +220,10 @@ class RarFile(object):
             if rarinfo is None:
                 data = None
 
+        except unrarlib.MissingPassword:
+            raise RuntimeError("File is encrypted, password required")
+        except unrarlib.BadPassword:
+            raise RuntimeError("Bad password for File")
         except unrarlib.BadDataError:
             if password is not None:
                 raise RuntimeError("File CRC error or incorrect password")

--- a/unrar/rarfile.py
+++ b/unrar/rarfile.py
@@ -343,6 +343,8 @@ class RarFile(object):
             raise RuntimeError("File is encrypted, password required")
         except unrarlib.BadPassword:
             raise RuntimeError("Bad password for File")
+        except unrarlib.BadDataError:
+            raise RuntimeError("File CRC Error")
         except unrarlib.UnrarException as e:
             raise BadRarFile("Bad RAR archive data: %s" % str(e))
         finally:

--- a/unrar/rarfile.py
+++ b/unrar/rarfile.py
@@ -121,6 +121,8 @@ class RarFile(object):
 
         # assert(archive.OpenResult == constants.SUCCESS)
         self.pwd = pwd
+        if self.pwd is not None:
+            unrarlib.RARSetPassword(handle, b(self.pwd))
         self.filelist = []
         self.NameToInfo = {}
         if archive.CmtState == constants.RAR_COMMENTS_SUCCESS:

--- a/unrar/tests/test_rarfile.py
+++ b/unrar/tests/test_rarfile.py
@@ -141,17 +141,17 @@ class TestCorruptedRar(TestRarFile):
         self.assertEqual(self.rar.testrar(), 'test_file.txt')
 
     def test_extract(self):
-        with self.assertRaises(BadRarFile):
+        with self.assertRaises(RuntimeError):
             super(TestCorruptedRar, self).test_extract()
 
     def test_extractall(self):
-        with self.assertRaises(BadRarFile):
+        with self.assertRaises(RuntimeError):
             super(TestCorruptedRar, self).test_extractall()
 
     def test_extract_to_memory(self):
-        with self.assertRaises(BadRarFile):
+        with self.assertRaises(RuntimeError):
             super(TestCorruptedRar, self).test_extract_to_memory()
 
     def test_read_to_memory(self):
-        with self.assertRaises(BadRarFile):
+        with self.assertRaises(RuntimeError):
             super(TestCorruptedRar, self).test_read_to_memory()

--- a/unrar/unrarlib.py
+++ b/unrar/unrarlib.py
@@ -73,6 +73,52 @@ def dostime_to_timetuple(dostime):
 class UnrarException(Exception):
     """Lib errors exception."""
 
+class ArchiveEnd(UnrarException):
+    """End of Archive event - code 10"""
+
+class NoMemoryError(UnrarException):
+    """No memory error - code 11"""
+
+class BadDataError(UnrarException):
+    """Bad data error - code 12"""
+
+class BadArchiveError(UnrarException):
+    """Bad archive error - code 13"""
+
+class UnknownFormatError(UnrarException):
+    """Unknown format error - code 14"""
+
+class OpenError(UnrarException):
+    """Open error - code 15"""
+
+class CreateError(UnrarException):
+    """Create error - code 16"""
+
+class CloseError(UnrarException):
+    """Close error - code 17"""
+
+class ReadError(UnrarException):
+    """Read error - code 18"""
+
+class WriteError(UnrarException):
+    """Write error - code 19"""
+
+class SmallBufError(UnrarException):
+    """Buffer too small error - code 20"""
+
+class UnknownError(UnrarException):
+    """Unknown error - code 21"""
+
+class MissingPassword(UnrarException):
+    """Missing password - code 22"""
+
+#ReferenceError is a built-in
+class RarReferenceError(UnrarException):
+    """Reference error - code 23"""
+
+class BadPassword(UnrarException):
+    """Bad password - code 24"""
+
 
 class _Structure(ctypes.Structure):
     """Customized ctypes Structure base class."""
@@ -167,36 +213,81 @@ def _check_open_result(res, func, args):
 
 
 def _check_readheader_result(res, func, args):
-    if res == constants.ERAR_BAD_DATA:
-        raise UnrarException("Bad header data.")
-    # res == SUCCESS | res == ERAR_END_ARCHIVE
-    return res
+    if res == constants.SUCCESS:
+        return res
+    elif res == constants.ERAR_END_ARCHIVE: #10
+        raise ArchiveEnd()
+    elif res == constants.ERAR_NO_MEMORY: #11
+        raise NoMemoryError("Not enough memory")
+    elif res == constants.ERAR_BAD_DATA: #12
+        raise BadDataError("Bad header data.")
+    elif res == constants.ERAR_BAD_ARCHIVE: #13
+        raise BadArchiveError("Not valid RAR archive")
+    elif res == constants.ERAR_UNKNOWN_FORMAT: #14
+        raise UnknownFormatError("Unknown archive format")
+    elif res == constants.ERAR_EOPEN: #15
+        raise OpenError("Volume open error")
+    elif res == constants.ERAR_ECREATE: #16
+        raise CreateError("File create error")
+    elif res == constants.ERAR_ECLOSE: #17
+        raise CloseError("File close error")
+    elif res == constants.ERAR_EREAD: #18
+        raise ReadError("Read error")
+    elif res == constants.ERAR_EWRITE: #19
+        raise WriteError("Write error")
+    elif res == constants.ERAR_SMALL_BUF: #20
+        raise SmallBufError("Buffer too small")
+    elif res == constants.ERAR_UNKNOWN: #21
+        raise UnknownError("Unknown error")
+    elif res == constants.ERAR_MISSING_PASSWORD: #22
+        raise MissingPassword("Password missing")
+    elif res == constants.ERAR_EREFERENCE: #23
+        raise RarReferenceError("Reference Error")
+    elif res == constants.ERAR_BAD_PASSWORD: #24
+        raise BadPassword("Bad password")
+    else:
+        raise UnrarException("Unknown Error")
 
 
 def _check_process_result(res, func, args):
-    if res == constants.ERAR_ECLOSE:
-        raise UnrarException("File close error")
-    elif res == constants.ERAR_BAD_DATA:
-        raise UnrarException("File CRC error")
-    elif res == constants.ERAR_BAD_ARCHIVE:
-        raise UnrarException("Not valid RAR archive")
-    elif res == constants.ERAR_UNKNOWN_FORMAT:
-        raise UnrarException("Unknown archive format")
-    elif res == constants.ERAR_EOPEN:
-        raise UnrarException("Volume open error")
-    elif res == constants.ERAR_ECREATE:
-        raise UnrarException("File create error")
-    elif res == constants.ERAR_EREAD:
-        raise UnrarException("Read error")
-    elif res == constants.ERAR_EWRITE:
-        raise UnrarException("Write error")
-    # res == SUCCESS | res == ERAR_END_ARCHIVE
-    return res
-
+    if res == constants.SUCCESS:
+        return res
+    elif res == constants.ERAR_END_ARCHIVE: #10
+        raise ArchiveEnd()
+    elif res == constants.ERAR_NO_MEMORY: #11
+        raise NoMemoryError("Not enough memory")
+    elif res == constants.ERAR_BAD_DATA: #12
+        raise BadDataError("File CRC error")
+    elif res == constants.ERAR_BAD_ARCHIVE: #13
+        raise BadArchive("Not valid RAR archive")
+    elif res == constants.ERAR_UNKNOWN_FORMAT: #14
+        raise UnknownFormat("Unknown archive format")
+    elif res == constants.ERAR_EOPEN: #15
+        raise OpenError("Volume open error")
+    elif res == constants.ERAR_ECREATE: #16
+        raise CreateError("File create error")
+    elif res == constants.ERAR_ECLOSE: #17
+        raise CloseError("File close error")
+    elif res == constants.ERAR_EREAD: #18
+        raise ReadError("Read error")
+    elif res == constants.ERAR_EWRITE: #19
+        raise WriteError("Write error")
+    elif res == constants.ERAR_SMALL_BUF: #20
+        raise SmallBufError("Buffer too small")
+    elif res == constants.ERAR_UNKNOWN: #21
+        raise UnknownError("Unknown Error")
+    elif res == constants.ERAR_MISSING_PASSWORD: #22
+        raise MissingPassword("Missing password")
+    elif res == constants.ERAR_EREFERENCE: #23
+        raise RarReferenceError("Reference Error")
+    elif res == constants.ERAR_BAD_PASSWORD: #24
+        raise BadPassword("Bad Password")
+    else:
+        raise UnrarException("Unknown Error")
 
 def _check_close_result(res, func, args):
     if res == constants.ERAR_ECLOSE:
-        raise UnrarException("Archive close error")
+        raise CloseError("Archive close error")
     # res == SUCCESS
     return res
 


### PR DESCRIPTION
Made some modifications to how errors are handled. Basically issue #3 is caused because unrarlib returns an error code that is not handled properly causing an infinite loop when trying to open a rar file that has its headers encrypted (the -hp flag in rar). Further I went ahead and created specific exception classes for every dll return code that exists in dll.hpp (including adding 23 and 24). Those specific classes are raised now in _check_process_result and _check_readheader_result but since all of them are based on UnrarException, you can technically still catch that. The biggest change is that ERAR_ARCHIVE_END is an exception that needs to be caught and dealt with. All non-error exceptions (e.g., ERAR_ARCHIVE_END, ERAR_MISSING_PASSWORD, etc are given non 'Error' names such as ArchiveEnd)

I've modified rarfile.py to match and also try to raise a RuntimeError in certain situation akin to the behavior of zipfile in those similar situations.

Also, if a rar file has an encrypted header, the password needs to be set before attempting to read the header, so I added a call to set the password in the init function if it was set.

And lastly there's a small/bug flaw in extract.cpp of the unrarlib whereby it will not return an ERAR_MISSING_PASSWORD if it attempts to extract a password protected file and a password is not set (I've emailed rarlabs to verify if this is a bug or I'm just missing something). As a work around, the callback function gets called to give you the opportunity to prompt the user to get a password, I just use this opportunity to mark that the file is encrypted and no password is provided so a RuntimeError can later be raised.