### PR TITLE
Provide code escape for partial volumes.

### DIFF
--- a/unrar/rarfile.py
+++ b/unrar/rarfile.py
@@ -126,6 +126,8 @@ class RarFile(object):
 
         archive = unrarlib.RAROpenArchiveDataEx(filename, mode=mode)
         handle = self._open(archive)
+        if archive.Flags & 0x01:
+            raise RuntimeError("Archive is part of a volume")
 
         # assert(archive.OpenResult == constants.SUCCESS)
         self.pwd = pwd


### PR DESCRIPTION
rarfile.py hangs inside `def _process_current()' when the rar is a partial archive. ex: test.part1.rar