### PR TITLE
Add support for MacOS

### DIFF
--- a/unrar/unrarlib.py
+++ b/unrar/unrarlib.py
@@ -20,6 +20,7 @@ import os
 import platform
 
 from ctypes.util import find_library
+from packaging import version
 
 from unrar import constants
 
@@ -57,29 +58,21 @@ else:
         if platform.system() == "Darwin":
             dylib_path = ""
             brew_unrar_path = "/usr/local/Cellar/unrar/"
-            latest_tested = "5.2.6"
             lib_filename = "libunrar.dylib"
+            version_dirs_parsed = []
 
-            # Is latest tested version installed?
-            latest_tested_path = f"{brew_unrar_path}{latest_tested}/lib/{lib_filename}"
-            if os.path.isfile(latest_tested_path):
-                dylib_path = latest_tested_path
+            if os.path.isdir(brew_unrar_path):
+                # Find latest installed version
+                for version_dirs in next(os.walk(brew_unrar_path))[1]:
+                    version_dirs_parsed.append(version.parse(version_dirs))
+
+                latest_version = max(version_dirs_parsed)
+                dylib_path = f"{brew_unrar_path}{latest_version}/lib/{lib_filename}"
                 unrarlib = ctypes.cdll.LoadLibrary(dylib_path)
-
-            # Check for other versions
-            version_dirs = []
-            for root, dirs, files in os.walk(brew_unrar_path):
-                if lib_filename in files:
-                    dirname = os.path.dirname(root)
-                    version_dirs.append(os.path.split(dirname)[1:][0])
-
-            # Wrong version(s) installed
-            if version_dirs is not None:
-                if unrarlib is None:
-                    raise LookupError(
-                    f"libunrar.dylib must be version {latest_tested}. "
-                    f"Installed versions: {version_dirs}"
-                    )
+            else:
+                raise LookupError(f"Couldn't locate libunrar.dylib. "
+                "Install it using Homebrew (https://brew.sh/), or build it yourself (https://www.rarlab.com/rar_add.htm)."
+                )
 
 
 if unrarlib is None:


### PR DESCRIPTION
I'm running MacOS 10.14.4. I've tried using both the libunrar version 5.2.6 mentioned in README.md as the latest tested version, and the latest stable (6.0.2), and everything seems to work just fine.

If there are no problems using 6.0.2, I think it makes sense to have the library installed via `brew`, as building and installing from source, requires editing the makefile or manually renaming and moving the binary. The makefile RARLab ships, tries to install it at /usr/lib/libunrar.so, which is not permitted by MacOS System Integrity Protection, and does not use the .dylib extension.

However, installing older versions using `brew` is an overwhelmingly [tedious process](https://stackoverflow.com/questions/3987683/homebrew-install-specific-version-of-formula), so if it turns out 6.0.2 isn't compatible, an alternative solution is needed.

Perhaps python-unrar could ship it's own makefile.
For example, here's an OS aware version of the one from RARLab:
<details>
  <summary>Click to expand code block</summary>

  ```make
#
# Makefile for UNIX - unrar

# UNIX using GCC
CXX=g++

UNAME_S := $(shell uname -s)
ifeq ($(UNAME_S),Linux)
		# Linux
    CCFLAGS += -D LINUX
		DESTDIR=/usr
		LIB_EXT=so
endif
ifeq ($(UNAME_S),Darwin)
		# MacOS
    CCFLAGS += -D OSX
		DESTDIR=/usr/local
		LIB_EXT=dylib
endif

CXXFLAGS=-O2
LIBFLAGS=-fPIC
DEFINES=-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DRAR_SMP
STRIP=strip
LDFLAGS=-pthread

COMPILE=$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(DEFINES)
LINK=$(CXX)

WHAT=UNRAR

UNRAR_OBJ=filestr.o recvol.o rs.o scantree.o qopen.o
LIB_OBJ=filestr.o scantree.o dll.o qopen.o

OBJECTS=rar.o strlist.o strfn.o pathfn.o smallfn.o global.o file.o filefn.o filcreat.o \
	archive.o arcread.o unicode.o system.o isnt.o crypt.o crc.o rawread.o encname.o \
	resource.o match.o timefn.o rdwrfn.o consio.o options.o errhnd.o rarvm.o secpassword.o \
	rijndael.o getbits.o sha1.o sha256.o blake2s.o hash.o extinfo.o extract.o volume.o \
  list.o find.o unpack.o headers.o threadpool.o rs16.o cmddata.o ui.o

.cpp.o:
	$(COMPILE) -D$(WHAT) -c $<

all:	unrar

install:	install-unrar

uninstall:	uninstall-unrar

clean:
	@rm -f *.o *.bak *~

unrar:	clean $(OBJECTS) $(UNRAR_OBJ)
	@rm -f unrar
	$(LINK) -o unrar $(LDFLAGS) $(OBJECTS) $(UNRAR_OBJ) $(LIBS)
	$(STRIP) unrar

sfx:	WHAT=SFX_MODULE
sfx:	clean $(OBJECTS)
	@rm -f default.sfx
	$(LINK) -o default.sfx $(LDFLAGS) $(OBJECTS)
	$(STRIP) default.sfx

lib:	WHAT=RARDLL
lib:	CXXFLAGS+=$(LIBFLAGS)
lib:	clean $(OBJECTS) $(LIB_OBJ)
	@rm -f libunrar.$(LIB_EXT)
	$(LINK) -shared -o libunrar.$(LIB_EXT) $(LDFLAGS) $(OBJECTS) $(LIB_OBJ)

install-unrar:
			install -D unrar $(DESTDIR)/bin/unrar

uninstall-unrar:
			rm -f $(DESTDIR)/bin/unrar

install-lib:
		install libunrar.$(LIB_EXT) $(DESTDIR)/lib

uninstall-lib:
		rm -f $(DESTDIR)/lib/libunrar.$(LIB_EXT)

  ```
</details>

The version finding mechanism in my code is a bit hacky, and I'm not sure which approach makes the most sense here. Let me know what you think.
