### PR TITLE
Avoid memory leaks when an error occurs

### DIFF
--- a/unrar/rarfile.py
+++ b/unrar/rarfile.py
@@ -137,8 +137,13 @@ class RarFile(object):
             self.comment = archive.CmtBuf.value
         else:
             self.comment = None
-        self._load_metadata(handle)
-        self._close(handle)
+            
+        try:
+          self._load_metadata(handle)
+        except Exception as e:
+          raise e
+        finally:
+          self._close(handle)
     
     def __enter__(self):
         return self


### PR DESCRIPTION
Hi,

I'm programming bruteforce password tester on rar file with your wrapper + lib.
Since I try and retry multiple password, I was able to detect some memory leaks (10GB / 2h).
Here is a patch :)

Thank's for your work !